### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -1,6 +1,9 @@
 name: Create module zip
 on: [ push ]
 
+permissions:
+  contents: read
+
 env:
   PROJECT_NAME: braintreeofficial
   PROJECT_VERSION: ${{ contains(github.ref_name, 'develop16') && '16-to-175' || '176-8-9' }}


### PR DESCRIPTION
Potential fix for [https://github.com/202ecommerce/braintreeofficial/security/code-scanning/2](https://github.com/202ecommerce/braintreeofficial/security/code-scanning/2)

In general, the fix is to add an explicit `permissions:` block to the workflow (either at the root, affecting all jobs, or inside the specific job) that grants only the minimum required permissions to `GITHUB_TOKEN`. For this workflow, the steps use `actions/checkout` to read the repository content and `actions/upload-artifact` to store build artifacts. They do not perform any writes to the GitHub repository or to issues, PRs, or other GitHub resources. Therefore, limiting `GITHUB_TOKEN` to `contents: read` is an appropriate minimal scope.

The single best way to fix this without altering functionality is to add a top-level `permissions:` section after the `on:` block, setting `contents: read`. This will apply to the `zip` job (which currently has no `permissions:` block of its own) and ensures the job can still check out repository code while preventing unnecessary write privileges. No other changes to steps, environment variables, or commands are needed.

Concretely, in `.github/workflows/zip.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 2 (`on: [ push ]`) and line 4 (`env:`). No additional imports or external dependencies are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
